### PR TITLE
Add car state classification prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-MLmodel
+# Car State Classification
+
+Prototype ML model that predicts whether a car is dirty and/or damaged from a photo.
+
+## Training
+
+Quick demo with synthetic data:
+
+```bash
+python train.py --fake-data --epochs 1
+```
+
+Training on a real dataset organised as:
+
+```
+data/
+  clean_intact/
+  clean_damaged/
+  dirty_intact/
+  dirty_damaged/
+```
+
+Run:
+
+```bash
+python train.py --data-dir data --epochs 10
+```
+
+## Prediction
+
+```bash
+python predict.py --model-path model.pth --image-path path/to/car.jpg
+```
+
+Or test with a random image:
+
+```bash
+python predict.py --model-path model.pth --fake
+```
+
+## Requirements
+
+Install dependencies:
+
+```bash
+pip install torch torchvision pillow
+```
+

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,43 @@
+import argparse
+import torch
+from torch import nn
+from torchvision import models, transforms
+from PIL import Image
+
+def load_model(path):
+    model = models.resnet18()
+    model.fc = nn.Linear(model.fc.in_features, 2)
+    state = torch.load(path, map_location='cpu')
+    model.load_state_dict(state)
+    model.eval()
+    return model
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Predict car state")
+    parser.add_argument('--model-path', required=True, help='Path to trained model')
+    parser.add_argument('--image-path', help='Path to image file')
+    parser.add_argument('--fake', action='store_true', help='Use random image instead')
+    args = parser.parse_args()
+
+    model = load_model(args.model_path)
+    transform = transforms.Compose([
+        transforms.Resize((224, 224)),
+        transforms.ToTensor(),
+    ])
+
+    if args.fake or not args.image_path:
+        image = torch.rand(3, 224, 224)
+    else:
+        image = transform(Image.open(args.image_path).convert('RGB'))
+
+    with torch.no_grad():
+        logits = model(image.unsqueeze(0))[0]
+        probs = torch.sigmoid(logits)
+    dirty_prob, damaged_prob = probs
+    print(f"dirty: {dirty_prob.item():.3f}, clean: {1 - dirty_prob.item():.3f}")
+    print(f"damaged: {damaged_prob.item():.3f}, intact: {1 - damaged_prob.item():.3f}")
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+torch
+torchvision
+Pillow

--- a/train.py
+++ b/train.py
@@ -1,0 +1,76 @@
+import argparse
+import torch
+from torch import nn, optim
+from torch.utils.data import Dataset, DataLoader
+from torchvision import datasets, transforms, models
+
+class FakeCarDataset(Dataset):
+    """Simple dataset generating random images and binary labels."""
+    def __init__(self, size=100):
+        self.size = size
+        self.data = torch.rand(size, 3, 224, 224)
+        self.labels = torch.randint(0, 2, (size, 2), dtype=torch.float32)
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        return self.data[idx], self.labels[idx]
+
+def load_real_data(data_dir, batch_size):
+    transform = transforms.Compose([
+        transforms.Resize((224, 224)),
+        transforms.ToTensor(),
+    ])
+    dataset = datasets.ImageFolder(data_dir, transform=transform)
+    def target_transform(index):
+        class_name = dataset.classes[index]
+        dirty = 1 if 'dirty' in class_name else 0
+        damaged = 1 if 'damaged' in class_name or 'scratch' in class_name else 0
+        return torch.tensor([dirty, damaged], dtype=torch.float32)
+    dataset.target_transform = target_transform
+    return DataLoader(dataset, batch_size=batch_size, shuffle=True)
+
+
+def train(args):
+    if args.fake_data:
+        loader = DataLoader(FakeCarDataset(size=64), batch_size=args.batch_size, shuffle=True)
+    else:
+        loader = load_real_data(args.data_dir, args.batch_size)
+
+    # Use randomly initialised weights to avoid downloading pretrained models
+    model = models.resnet18(weights=None)
+    model.fc = nn.Linear(model.fc.in_features, 2)
+
+    criterion = nn.BCEWithLogitsLoss()
+    optimizer = optim.Adam(model.parameters(), lr=args.lr)
+
+    model.train()
+    for epoch in range(args.epochs):
+        running_loss = 0.0
+        for images, targets in loader:
+            optimizer.zero_grad()
+            outputs = model(images)
+            loss = criterion(outputs, targets)
+            loss.backward()
+            optimizer.step()
+            running_loss += loss.item()
+        print(f"Epoch {epoch+1}: loss {running_loss/len(loader):.4f}")
+    torch.save(model.state_dict(), args.output)
+    print(f"Model saved to {args.output}")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Train car state classifier")
+    p.add_argument('--data-dir', type=str, default='data', help='Path to dataset root')
+    p.add_argument('--epochs', type=int, default=5)
+    p.add_argument('--batch-size', type=int, default=16)
+    p.add_argument('--lr', type=float, default=1e-3)
+    p.add_argument('--output', type=str, default='model.pth')
+    p.add_argument('--fake-data', action='store_true', help='Use random data for quick demo')
+    return p.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    train(args)


### PR DESCRIPTION
## Summary
- add training script using ResNet18 to classify dirty and damaged cars
- add prediction script for running inference on photos
- document usage and dependencies in README and requirements

## Testing
- `pip install torch torchvision pillow`
- `python train.py --fake-data --epochs 1 --batch-size 4`
- `python predict.py --model-path model.pth --fake`


------
https://chatgpt.com/codex/tasks/task_e_68c6ad72d7cc832a8457659e0b15028f